### PR TITLE
Fixed `globe.svg` not working

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box, Button, Container, Paper, Typography } from "@mui/material";
-import Image from "next/image";
 import Link from "next/link";
 
 export default function NotFound() {
@@ -44,19 +43,10 @@ export default function NotFound() {
             >
               404
             </Typography>
-            <Image
-              src="/globe.svg"
-              alt="Student Merit Management System Logo"
-              width={60}
-              height={60}
-              priority
-            />
           </Box>
-
           <Typography variant="h4" component="h2" sx={{ mb: 3 }}>
             Page Not Found
           </Typography>
-
           <Typography
             variant="body1"
             color="text.secondary"
@@ -65,7 +55,6 @@ export default function NotFound() {
             The page you&apos;re looking for doesn&apos;t exist or has been
             moved. Please check the URL or return to the homepage.
           </Typography>
-
           <Box sx={{ display: "flex", gap: 2 }}>
             <Button
               component={Link}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormError } from "@/components/ui/ErrorDisplay";
+import GlobeIcon from "@/components/common/GlobeIcon";
 import { useAuth } from "@/hooks/useAuth";
 import { useFormState } from "@/hooks/useFormState";
 import { AUTH_COOKIE_EXPIRES_DAYS, AUTH_COOKIE_NAME } from "@/lib/constants";
@@ -223,38 +224,15 @@ export default function LoginForm({
 function AppLogo() {
   return (
     <Box sx={{ mb: 4, textAlign: "center" }}>
-      {/* Inline SVG to avoid loading issues */}
-      <Box
+      <GlobeIcon
+        width={80}
+        height={80}
         sx={{
-          width: 80,
-          height: 80,
           display: "block",
           margin: "0 auto",
           mb: 1,
         }}
-      >
-        <svg
-          width="80"
-          height="80"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 16 16"
-        >
-          <g clipPath="url(#a)">
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M10.27 14.1a6.5 6.5 0 0 0 3.67-3.45q-1.24.21-2.7.34-.31 1.83-.97 3.1M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m.48-1.52a7 7 0 0 1-.96 0H7.5a4 4 0 0 1-.84-1.32q-.38-.89-.63-2.08a40 40 0 0 0 3.92 0q-.25 1.2-.63 2.08a4 4 0 0 1-.84 1.31zm2.94-4.76q1.66-.15 2.95-.43a7 7 0 0 0 0-2.58q-1.3-.27-2.95-.43a18 18 0 0 1 0 3.44m-1.27-3.54a17 17 0 0 1 0 3.64 39 39 0 0 1-4.3 0 17 17 0 0 1 0-3.64 39 39 0 0 1 4.3 0m1.1-1.17q1.45.13 2.69.34a6.5 6.5 0 0 0-3.67-3.44q.65 1.26.98 3.1M8.48 1.5l.01.02q.41.37.84 1.31.38.89.63 2.08a40 40 0 0 0-3.92 0q.25-1.2.63-2.08a4 4 0 0 1 .85-1.32 7 7 0 0 1 .96 0m-2.75.4a6.5 6.5 0 0 0-3.67 3.44 29 29 0 0 1 2.7-.34q.31-1.83.97-3.1M4.58 6.28q-1.66.16-2.95.43a7 7 0 0 0 0 2.58q1.3.27 2.95.43a18 18 0 0 1 0-3.44m.17 4.71q-1.45-.12-2.69-.34a6.5 6.5 0 0 0 3.67 3.44q-.65-1.27-.98-3.1"
-              fill="#1976d2"
-            />
-          </g>
-          <defs>
-            <clipPath id="a">
-              <path fill="#fff" d="M0 0h16v16H0z" />
-            </clipPath>
-          </defs>
-        </svg>
-      </Box>
+      />
       <Typography variant="h4" component="h1" sx={{ mt: 2, fontWeight: 700 }}>
         Merit System
       </Typography>

--- a/src/components/common/GlobeIcon.tsx
+++ b/src/components/common/GlobeIcon.tsx
@@ -1,0 +1,57 @@
+import { Box } from "@mui/material";
+
+interface GlobeIconProps {
+  /** Width of the icon in pixels */
+  width?: number;
+  /** Height of the icon in pixels */
+  height?: number;
+  /** Color of the icon (CSS color value) */
+  color?: string;
+  /** Additional sx styling props */
+  sx?: object;
+}
+
+/**
+ * GlobeIcon component - A reusable globe/world icon using inline SVG
+ * This component avoids external file loading issues and works reliably
+ * across different contexts including Suspense boundaries.
+ */
+export default function GlobeIcon({
+  width = 80,
+  height = 80,
+  color = "#1976d2",
+  sx = {},
+}: GlobeIconProps) {
+  return (
+    <Box
+      sx={{
+        width,
+        height,
+        display: "inline-block",
+        ...sx,
+      }}
+    >
+      <svg
+        width={width}
+        height={height}
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+      >
+        <g clipPath="url(#globe-clip)">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M10.27 14.1a6.5 6.5 0 0 0 3.67-3.45q-1.24.21-2.7.34-.31 1.83-.97 3.1M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m.48-1.52a7 7 0 0 1-.96 0H7.5a4 4 0 0 1-.84-1.32q-.38-.89-.63-2.08a40 40 0 0 0 3.92 0q-.25 1.2-.63 2.08a4 4 0 0 1-.84 1.31zm2.94-4.76q1.66-.15 2.95-.43a7 7 0 0 0 0-2.58q-1.3-.27-2.95-.43a18 18 0 0 1 0 3.44m-1.27-3.54a17 17 0 0 1 0 3.64 39 39 0 0 1-4.3 0 17 17 0 0 1 0-3.64 39 39 0 0 1 4.3 0m1.1-1.17q1.45.13 2.69.34a6.5 6.5 0 0 0-3.67-3.44q.65 1.26.98 3.1M8.48 1.5l.01.02q.41.37.84 1.31.38.89.63 2.08a40 40 0 0 0-3.92 0q.25-1.2.63-2.08a4 4 0 0 1 .85-1.32 7 7 0 0 1 .96 0m-2.75.4a6.5 6.5 0 0 0-3.67 3.44 29 29 0 0 1 2.7-.34q.31-1.83.97-3.1M4.58 6.28q-1.66.16-2.95.43a7 7 0 0 0 0 2.58q1.3.27 2.95.43a18 18 0 0 1 0-3.44m.17 4.71q-1.45-.12-2.69-.34a6.5 6.5 0 0 0 3.67 3.44q-.65-1.27-.98-3.1"
+            fill={color}
+          />
+        </g>
+        <defs>
+          <clipPath id="globe-clip">
+            <path fill="#fff" d="M0 0h16v16H0z" />
+          </clipPath>
+        </defs>
+      </svg>
+    </Box>
+  );
+}


### PR DESCRIPTION
# Changes

- Made the `globe.svg` into a `<GlobeIcon />` component for ease-of-use.
- Removed the globe icon from `not-found.tsx` for simplicity.

# Additional Notes

- Create a component to handle SVGs in general, especially for ones that are wrapped around `Suspense` components.